### PR TITLE
Add local.settings.json to template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,6 @@ out
 bin
 obj
 appsettings.json
-local.settings.json
 
 # Azurite artifacts
 __blobstorage__

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This source code supports the article [Quickstart: Create and deploy functions t
 ## Prerequisites
 
 + [Node.js 20](https://www.nodejs.org/) 
++ [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) (for local storage emulation)
 + [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?pivots=programming-language-javascript#install-the-azure-functions-core-tools)
 + [Azure Developer CLI (`azd`)](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd)
 + To use Visual Studio Code to run and debug locally:
@@ -52,24 +53,20 @@ You can initialize a project from this `azd` template in one of these ways:
     ```
 
     You can also clone the repository from your own fork in GitHub.
+## Local settings
 
-## Prepare your local environment
+The `local.settings.json` file is included in this template with default values for local development. This file is excluded from deployment by `.funcignore`.
 
-Add a file named `local.settings.json` in the root of your project with the following contents:
-
-```json
-{
-    "IsEncrypted": false,
-    "Values": {
-    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "node"
-    }
-}
-```
 
 ## Run your app from the terminal
 
-1. Run these commands to start the Functions host locally:
+1. Start Azurite for local storage emulation. In a separate terminal, run:
+
+    ```shell
+    azurite
+    ```
+
+1. Run these commands to start the Functions host:
 
     ```shell
     npm install

--- a/local.settings.json
+++ b/local.settings.json
@@ -1,0 +1,7 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "node"
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds `local.settings.json` directly to the template, eliminating the manual file creation step from the README.

## Changes

| File | Change |
|------|--------|
| `local.settings.json` | **Added** with base settings |
| `.gitignore` | **Removed** `local.settings.json` line (so file ships with template) |
| `.funcignore` | **No change** (keeps excluding from deployment) |
| `README.md` | **Updated**: Added Azurite prereq, added Azurite start step, removed manual creation instructions |

## Why

- **Better DX**: Developers get a working setup immediately after `azd init`
- **No secrets**: Only contains safe default values
- **Still protected**: `.funcignore` prevents deployment to Azure
- **Azurite required**: `UseDevelopmentStorage=true` requires Azurite for local storage emulation

## Tracking

- https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/973